### PR TITLE
Fix Typo in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ termimad::print_inline("**some** *nested **style*** and `some(code)`");
 ```
 or
 ```rust
-print!("{}", termimad.inline("**some** *nested **style*** and `some(code)`"));
+print!("{}", termimad::inline("**some** *nested **style*** and `some(code)`"));
 ```
 
 Result:


### PR DESCRIPTION
Using path namespace qualifier `::`  instead of  `.` for a method