### PR TITLE
chore: re-export crossterm as module

### DIFF
--- a/examples/ask/main.rs
+++ b/examples/ask/main.rs
@@ -2,7 +2,7 @@
 //!   cargo run --example ask
 //!
 use {
-    crossterm::{
+    termimad::crossterm::{
         style::Color::*,
     },
     termimad::*,

--- a/examples/fit_width/main.rs
+++ b/examples/fit_width/main.rs
@@ -2,15 +2,15 @@
 //!   cargo run --example fit_width
 //!
 use {
-    crossterm::{
+    minimad::Composite,
+    std::io::{stderr, Write},
+    termimad::crossterm::{
         cursor::{self, Hide, Show},
         event::{self, Event},
         ExecutableCommand,
         terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
         style::Color::*,
     },
-    minimad::Composite,
-    std::io::{stderr, Write},
     termimad::*,
 };
 

--- a/examples/inline-template/main.rs
+++ b/examples/inline-template/main.rs
@@ -6,9 +6,9 @@ You execute this example with
      cargo run --example inline-template
 */
 use {
-    crossterm::style::{Attribute::*, Color::*},
     std::io::Write,
     minimad::mad_inline,
+    termimad::crossterm::style::{Attribute::*, Color::*},
     termimad::*,
 };
 

--- a/examples/render-input-markdown/main.rs
+++ b/examples/render-input-markdown/main.rs
@@ -13,7 +13,8 @@ mod view;
 use {
     anyhow::{self},
     crokey::key,
-    crossterm::{
+    std::io::{BufWriter, stdout, Write},
+    termimad::crossterm::{
         cursor,
         event::{
             DisableMouseCapture, EnableMouseCapture,
@@ -24,7 +25,6 @@ use {
         },
         QueueableCommand,
     },
-    std::io::{BufWriter, stdout, Write},
     termimad::*,
 };
 

--- a/examples/render-input-markdown/view.rs
+++ b/examples/render-input-markdown/view.rs
@@ -2,7 +2,8 @@ use {
     crate::clipboard,
     anyhow::{self},
     crokey::key,
-    crossterm::{
+    std::io::Write,
+    termimad::crossterm::{
         event::{Event, KeyEvent, MouseEvent},
         queue,
         terminal::{
@@ -10,7 +11,6 @@ use {
             ClearType,
         },
     },
-    std::io::Write,
     termimad::*,
 };
 

--- a/examples/scrollable/main.rs
+++ b/examples/scrollable/main.rs
@@ -1,7 +1,8 @@
 //! run this example with
 //!   cargo run --example scrollable
 //!
-use crossterm::{
+use std::io::{stdout, Write};
+use termimad::crossterm::{
     cursor::{ Hide, Show},
     event::{
         self,
@@ -19,7 +20,6 @@ use crossterm::{
     },
     style::Color::*,
 };
-use std::io::{stdout, Write};
 use termimad::*;
 
 fn view_area() -> Area {

--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -1,4 +1,4 @@
-use crossterm::style::{Attribute::*, Color::*};
+use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
 
 fn show(skin: &MadSkin, src: &str) {

--- a/examples/stderr/main.rs
+++ b/examples/stderr/main.rs
@@ -4,7 +4,7 @@
 //!   cargo run --example stderr
 //!
 
-use crossterm::{
+use termimad::crossterm::{
     event::{
         self,
         Event,

--- a/examples/table/main.rs
+++ b/examples/table/main.rs
@@ -1,4 +1,4 @@
-use crossterm::style::Color::*;
+use termimad::crossterm::style::Color::*;
 use termimad::*;
 
 static MD_TABLE: &str = r#"

--- a/examples/text-template/main.rs
+++ b/examples/text-template/main.rs
@@ -6,8 +6,8 @@ You execute this example with
 */
 
 use {
-    crossterm::style::Color::*,
     minimad::{TextTemplate, OwningTemplateExpander},
+    termimad::crossterm::style::Color::*,
     termimad::*,
 };
 

--- a/examples/text/main.rs
+++ b/examples/text/main.rs
@@ -1,4 +1,4 @@
-use crossterm::{execute, style::Color::*, terminal};
+use termimad::crossterm::{execute, style::Color::*, terminal};
 use termimad::*;
 
 static MD: &str = r#"

--- a/src/compound_style.rs
+++ b/src/compound_style.rs
@@ -227,7 +227,7 @@ impl CompoundStyle {
     ///
     /// ```
     /// # use termimad::*;
-    /// # use crossterm::terminal::ClearType;
+    /// # use termimad::crossterm::terminal::ClearType;
     /// # let skin = MadSkin::default();
     /// let mut w = std::io::stderr();
     /// skin.paragraph.compound_style.clear(&mut w, ClearType::UntilNewLine).unwrap();

--- a/src/fit/crop_writer.rs
+++ b/src/fit/crop_writer.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    crossterm::{style::Print, QueueableCommand},
+    crate::crossterm::{style::Print, QueueableCommand},
     std::borrow::Cow,
     unicode_width::UnicodeWidthChar,
 };

--- a/src/fit/filling.rs
+++ b/src/fit/filling.rs
@@ -1,7 +1,7 @@
 
 use {
     crate::*,
-    crossterm::{
+    crate::crossterm::{
         QueueableCommand,
         style::Print,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ to your tastes or (better) to your application's configuration.
 
 
 ```rust
-use crossterm::style::{Color::*, Attribute::*};
+use termimad::crossterm::style::{Color::*, Attribute::*};
 use termimad::*;
 
 // start with the default skin
@@ -127,6 +127,10 @@ mod tbl;
 mod text;
 mod tokens;
 mod views;
+
+pub mod crossterm {
+    pub use crossterm::*;
+}
 
 pub use {
     ask::*,

--- a/src/views/input_field.rs
+++ b/src/views/input_field.rs
@@ -1,7 +1,7 @@
 use {
     super::*,
     crate::*,
-    crossterm::{
+    crate::crossterm::{
         cursor,
         event::{
             Event,
@@ -276,7 +276,7 @@ impl InputField {
             self.insert_new_line();
             return true;
         }
-        use crossterm::event::{
+        use crate::crossterm::event::{
             KeyModifiers as Mod,
         };
         match (key.code, key.modifiers) {


### PR DESCRIPTION
This PR re-exports the `crossterm` crate as a module. This allows you to configure and use the `termimad` crate directly without needing to specify two separate dependencies and look in the README to see which version of `crossterm` we should use in order to compile this crate.