### PR TITLE
Serialize skin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ special-renders = []
 default = ["special-renders"]
 
 [dependencies]
-minimad = "0.13.0"
 coolor = { version="0.7.0", features=["crossterm"] }
-crossterm = "=0.23.2"
 crossbeam = "0.8"
+crossterm = "=0.23.2"
 lazy-regex = "3"
+minimad = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 unicode-width = "0.1.10"
@@ -32,6 +32,8 @@ anyhow = "1.0"
 cli-log = "2"
 crokey = "0.4"
 deser-hjson = "2"
+pretty_assertions = "1.4"
+serde_json = "1"
 terminal-clipboard = ">=0.3.1"
 
 [patch.crates-io]

--- a/examples/serialize-skin/main.rs
+++ b/examples/serialize-skin/main.rs
@@ -1,0 +1,48 @@
+//! this example prints a skin as JSON to stdout.
+//!
+//! Run it with `cargo run --example serialize-skin`
+use {
+    termimad::{
+        ansi,
+        gray,
+        ROUNDED_TABLE_BORDER_CHARS,
+        rgb,
+        StyledChar,
+        minimad::Alignment,
+    },
+    crossterm::style::{
+        Attribute,
+        Color::*,
+    },
+};
+
+/// Set this to true if you want to see a skin with a lot of changes
+/// from the default, set it to false to export the default skin
+const FANCY: bool = true;
+
+fn main() {
+    let mut skin = termimad::MadSkin::default();
+    if FANCY {
+        skin.set_headers_fg(AnsiValue(178));
+        skin.headers[0].set_bg(ansi(129));
+        skin.headers[1].add_attr(Attribute::Bold);
+        // note: gray(22) will appear as ansi(254) in the output,
+        // it's the same color
+        skin.headers[2].set_fg(gray(22));
+        skin.bold.set_fg(Yellow);
+        skin.italic.set_fgbg(Magenta, rgb(30, 30, 40));
+        skin.bullet = StyledChar::from_fg_char(Yellow, '⟡');
+        skin.quote_mark.set_fg(Yellow);
+        skin.italic.set_fg(Magenta);
+        skin.scrollbar.thumb.set_fg(AnsiValue(178));
+        skin.table_border_chars = ROUNDED_TABLE_BORDER_CHARS;
+        skin.paragraph.align = Alignment::Center;
+        skin.table.align = Alignment::Center;
+        skin.inline_code.add_attr(Attribute::Reverse);
+        skin.paragraph.set_fg(Magenta);
+        skin.italic.add_attr(Attribute::Underlined);
+        skin.italic.add_attr(Attribute::OverLined);
+    }
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    println!("{serialized}");
+}

--- a/examples/serialize-skin/skin.hjson
+++ b/examples/serialize-skin/skin.hjson
@@ -1,0 +1,18 @@
+# This Hjson file is an example skin.
+# You can modify it then run `cargo run --example skin-file`
+
+bold: "#fb0 bold"
+italic: dim italic
+strikeout: crossedout red
+bullet: ○ yellow bold
+paragraph: gray(20)
+code_block: gray(2) gray(15) center
+headers: [
+    yellow bold center
+    yellow underlined
+    yellow
+]
+quote: > red
+horizontal-rule: "~ #00cafe"
+table: "#540 center"
+scrollbar: "red yellow"

--- a/examples/skin-file/main.rs
+++ b/examples/skin-file/main.rs
@@ -74,9 +74,28 @@ They're defined like inline styles but accept an optional alignment (`left`, `ri
 
 ### Styled chars
 
-Styled chars are "bullet", "quote", "scrollbar", and "horizontal-rule".
+Styled chars are "bullet", "quote", and "horizontal-rule".
 
 They're defined by a character (which must be one character wide and long), and foreground and background colors. All parts are optional.
+
+### Scrolled bar
+
+It's defined either by
+* a char, a fg color and a bg color, all parts optional
+* a struct with two styled chars named `track` and `thumb`
+
+Examples:
+
+```Hjson
+scrollbar: white
+```
+
+```Hjson
+scrollbar: {
+    track: | darkblue black
+    thumb: | lightblue black bold
+}
+```
 
 ### Headers:
 

--- a/examples/skin-file/skin.json
+++ b/examples/skin-file/skin.json
@@ -1,0 +1,25 @@
+{
+  "bold": "Yellow Bold",
+  "italic": "Magenta rgb(30, 30, 40) Italic Underlined OverLined",
+  "strikeout": "CrossedOut",
+  "inline_code": "ansi(249) ansi(235) Reverse",
+  "ellipsis": "",
+  "bullet": "⟡ Yellow",
+  "quote": "▐ Yellow Bold",
+  "horizontal_rule": "― ansi(238)",
+  "scrollbar": "▐ ansi(178) ansi(237)",
+  "paragraph": "Magenta center",
+  "code_block": "ansi(249) ansi(235) ",
+  "table": "ansi(239) center",
+  "headers": [
+    "ansi(178) ansi(129) Bold Underlined center",
+    "ansi(178) Bold Underlined ",
+    "ansi(254) Underlined ",
+    "ansi(178) Underlined ",
+    "ansi(178) Underlined ",
+    "ansi(178) Underlined ",
+    "ansi(178) Underlined ",
+    "ansi(178) Underlined "
+  ],
+  "table_border_chars": "rounded"
+}

--- a/examples/text/main.rs
+++ b/examples/text/main.rs
@@ -14,8 +14,6 @@ skin.set_headers_fg(rgb(255, 187, 0));
 skin.bold.set_fg(Yellow);
 skin.italic.set_fgbg(Magenta, rgb(30, 30, 40));
 skin.bullet = StyledChar::from_fg_char(Yellow, '⟡');
-skin.quote_mark = StyledChar::from_fg_char(Yellow, '▐');
-skin.bullet = StyledChar::from_fg_char(Yellow, '⟡');
 skin.quote_mark.set_fg(Yellow);
 println!("{}", skin.term_text(my_markdown));
 ```

--- a/src/compound_style.rs
+++ b/src/compound_style.rs
@@ -34,7 +34,7 @@ pub static ATTRIBUTES: &[Attribute] = &[
 
 
 /// A style which may be applied to a compound
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct CompoundStyle {
     pub object_style: ContentStyle, // a crossterm content style
 }

--- a/src/line_style.rs
+++ b/src/line_style.rs
@@ -10,7 +10,7 @@ use {
 /// It's made of
 ///  - the base style of the compounds
 ///  - the alignment
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct LineStyle {
     pub compound_style: CompoundStyle,
     pub align: Alignment,

--- a/src/parse/parse_align.rs
+++ b/src/parse/parse_align.rs
@@ -1,12 +1,22 @@
 use {
     minimad::Alignment,
     lazy_regex::*,
+    std::fmt,
 };
 
 #[derive(thiserror::Error, Debug)]
 pub enum ParseAlignError {
     #[error("not a valid alignment")]
     Unrecognized,
+}
+
+pub fn write_align(f: &mut fmt::Formatter<'_>, a: Alignment) -> fmt::Result {
+    match a {
+        Alignment::Left => write!(f, "left"),
+        Alignment::Center => write!(f, "center"),
+        Alignment::Right => write!(f, "right"),
+        Alignment::Unspecified => Ok(()),
+    }
 }
 
 /// Read a Minimad Alignment from a string.

--- a/src/parse/parse_attribute.rs
+++ b/src/parse/parse_attribute.rs
@@ -3,12 +3,43 @@ use {
         Attribute,
     },
     lazy_regex::*,
+    std::fmt,
 };
 
 #[derive(thiserror::Error, Debug)]
 pub enum ParseAttributeError {
     #[error("not a recognized attribute")]
     Unrecognized,
+}
+
+pub fn write_attribute(f: &mut fmt::Formatter<'_>, a: Attribute) -> fmt::Result {
+    match a {
+        Attribute::Reset => Ok(()),
+        Attribute::Bold => write!(f, "Bold"),
+        Attribute::Dim => write!(f, "Dim"),
+        Attribute::Italic => write!(f, "Italic"),
+        Attribute::Underlined => write!(f, "Underlined"),
+        Attribute::SlowBlink => write!(f, "SlowBlink"),
+        Attribute::RapidBlink => write!(f, "RapidBlink"),
+        Attribute::Reverse => write!(f, "Reverse"),
+        Attribute::Hidden => write!(f, "Hidden"),
+        Attribute::CrossedOut => write!(f, "CrossedOut"),
+        Attribute::Fraktur => write!(f, "Fraktur"),
+        Attribute::NoBold => write!(f, "NoBold"),
+        Attribute::NormalIntensity => write!(f, "NormalIntensity"),
+        Attribute::NoItalic => write!(f, "NoItalic"),
+        Attribute::NoUnderline => write!(f, "NoUnderline"),
+        Attribute::NoBlink => write!(f, "NoBlink"),
+        Attribute::NoReverse => write!(f, "NoReverse"),
+        Attribute::NoHidden => write!(f, "NoHidden"),
+        Attribute::NotCrossedOut => write!(f, "NotCrossedOut"),
+        Attribute::Framed => write!(f, "Framed"),
+        Attribute::Encircled => write!(f, "Encircled"),
+        Attribute::OverLined => write!(f, "OverLined"),
+        Attribute::NotFramedOrEncircled => write!(f, "NotFramedOrEncircled"),
+        Attribute::NotOverLined => write!(f, "NotOverLined"),
+        _ => Ok(()),
+    }
 }
 
 /// Read a Minimad Attributement from a string.

--- a/src/parse/parse_color.rs
+++ b/src/parse/parse_color.rs
@@ -6,6 +6,7 @@ use {
     },
     crossterm::style::Color,
     lazy_regex::*,
+    std::fmt,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -14,6 +15,30 @@ pub enum ParseColorError {
     Unrecognized,
     #[error("grey level must be between 0 and 23 (got {level})")]
     InvalidGreyLevel { level: u8 },
+}
+
+pub fn write_color(f: &mut fmt::Formatter<'_>, c: Color) -> fmt::Result {
+    match c {
+        Color::Reset => Ok(()),
+        Color::Black => write!(f, "Black"),
+        Color::DarkGrey => write!(f, "DarkGrey"),
+        Color::Red => write!(f, "Red"),
+        Color::DarkRed => write!(f, "DarkRed"),
+        Color::Green => write!(f, "Green"),
+        Color::DarkGreen => write!(f, "DarkGreen"),
+        Color::Yellow => write!(f, "Yellow"),
+        Color::DarkYellow => write!(f, "DarkYellow"),
+        Color::Blue => write!(f, "Blue"),
+        Color::DarkBlue => write!(f, "DarkBlue"),
+        Color::Magenta => write!(f, "Magenta"),
+        Color::DarkMagenta => write!(f, "DarkMagenta"),
+        Color::Cyan => write!(f, "Cyan"),
+        Color::DarkCyan => write!(f, "DarkCyan"),
+        Color::White => write!(f, "White"),
+        Color::Grey => write!(f, "Grey"),
+        Color::Rgb { r, g, b } => write!(f, "rgb({r}, {g}, {b})"),
+        Color::AnsiValue(code) => write!(f, "ansi({code})"),
+    }
 }
 
 /// Read a Crossterm color from a string.

--- a/src/parse/parse_compound_style.rs
+++ b/src/parse/parse_compound_style.rs
@@ -1,9 +1,22 @@
 use {
     super::*,
-    crate::CompoundStyle,
+    crate::{
+        ATTRIBUTES,
+        CompoundStyle,
+    },
 };
 
 /// Read a Minimad CompoundStyle from a string.
+///
+/// May contain attributes and from 0 to 2 colors, the first encountered
+/// one being the foreground.
+///
+/// Examples:
+/// * `#ab00c1 strikeout`
+/// * `"red yellow bold italic"`
+/// * `""`
+/// * `"gray(2) gray(20)"`
+/// * `""`
 pub fn parse_compound_style(s: &str) -> Result<CompoundStyle, ParseStyleTokenError> {
     let tokens = parse_style_tokens(s)?;
     Ok(tokens.as_slice().into())
@@ -42,5 +55,23 @@ impl From<&[StyleToken]> for CompoundStyle {
             }
         }
         style
+    }
+}
+
+impl PushStyleTokens for CompoundStyle {
+    fn push_style_tokens(&self, tokens: &mut Vec<StyleToken>) {
+        if let Some(fg) = self.get_fg() {
+            tokens.push(StyleToken::Color(fg));
+        } else if self.get_bg().is_some() {
+            tokens.push(StyleToken::None);
+        }
+        if let Some(bg) = self.get_bg() {
+            tokens.push(StyleToken::Color(bg));
+        }
+        for &attr in ATTRIBUTES {
+            if self.has_attr(attr) {
+                tokens.push(StyleToken::Attribute(attr));
+            }
+        }
     }
 }

--- a/src/parse/parse_line_style.rs
+++ b/src/parse/parse_line_style.rs
@@ -24,3 +24,10 @@ impl From<&[StyleToken]> for LineStyle {
         LineStyle { compound_style, align }
     }
 }
+
+impl PushStyleTokens for LineStyle {
+    fn push_style_tokens(&self, tokens: &mut Vec<StyleToken>) {
+        self.compound_style.push_style_tokens(tokens);
+        tokens.push(StyleToken::Align(self.align));
+    }
+}

--- a/src/parse/parse_styled_char.rs
+++ b/src/parse/parse_styled_char.rs
@@ -19,3 +19,10 @@ pub fn parse_styled_char(s: &str, default_nude_char: char) -> Result<StyledChar,
     Ok(StyledChar::new(style, nude_char))
 }
 
+impl PushStyleTokens for StyledChar {
+    fn push_style_tokens(&self, tokens: &mut Vec<StyleToken>) {
+        tokens.push(StyleToken::Char(self.nude_char()));
+        self.compound_style().push_style_tokens(tokens);
+    }
+}
+

--- a/src/scrollbar_style.rs
+++ b/src/scrollbar_style.rs
@@ -11,7 +11,7 @@ use {
 ///
 /// For the default styling only the fg color is defined
 ///  and the char is ▐ but everything can be changed.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ScrollBarStyle {
     pub track: StyledChar,
     pub thumb: StyledChar,

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,6 +1,12 @@
-mod deser_skin;
-mod deser_compound_style;
-mod deser_line_style;
-mod deser_styled_char;
+mod serde_skin;
+mod serde_compound_style;
+mod serde_line_style;
+mod serde_scrollbar_style;
+mod serde_styled_char;
+
+pub use {
+    serde_scrollbar_style::*,
+};
+
 
 

--- a/src/serde/serde_compound_style.rs
+++ b/src/serde/serde_compound_style.rs
@@ -2,8 +2,9 @@ use {
     crate::{
         CompoundStyle,
         parse_compound_style,
+        parse::PushStyleTokens,
     },
-    serde::de,
+    serde::{de, Serialize, Serializer},
 };
 
 impl<'de> de::Deserialize<'de> for CompoundStyle {
@@ -16,3 +17,11 @@ impl<'de> de::Deserialize<'de> for CompoundStyle {
     }
 }
 
+impl Serialize for CompoundStyle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_style_tokens_string())
+    }
+}

--- a/src/serde/serde_line_style.rs
+++ b/src/serde/serde_line_style.rs
@@ -2,8 +2,9 @@ use {
     crate::{
         LineStyle,
         parse_line_style,
+        parse::PushStyleTokens,
     },
-    serde::de,
+    serde::{de, Serialize, Serializer},
 };
 
 impl<'de> de::Deserialize<'de> for LineStyle {
@@ -13,5 +14,14 @@ impl<'de> de::Deserialize<'de> for LineStyle {
     {
         let s = String::deserialize(deserializer)?;
         parse_line_style(&s).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for LineStyle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_style_tokens_string())
     }
 }

--- a/src/serde/serde_scrollbar_style.rs
+++ b/src/serde/serde_scrollbar_style.rs
@@ -1,0 +1,59 @@
+use {
+    crate::{
+        CompoundStyle,
+        ScrollBarStyle,
+        StyledChar,
+    },
+    serde::{
+        Deserialize,
+        Serialize,
+    },
+};
+
+/// A variable-complexity definition of a scrollbar,
+/// allowing a simplified representation covering most
+/// cases.
+///
+/// You should not use this enum unless you're writing
+/// your own skin type Serialize/Deserialize impls.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ScrollBarStyleDef {
+    Simple(StyledChar),
+    Rich {
+        track: StyledChar,
+        thumb: StyledChar,
+    },
+}
+
+impl From<&ScrollBarStyle> for ScrollBarStyleDef {
+    fn from(sc: &ScrollBarStyle) -> Self {
+        let simple = sc.track.nude_char() == sc.thumb.nude_char()
+            && sc.track.get_bg().is_none()
+            && sc.thumb.get_bg().is_none();
+        if simple {
+            Self::Simple(StyledChar::new(
+                CompoundStyle::new(
+                    sc.thumb.get_fg(),
+                    sc.track.get_fg(),
+                    Default::default(),
+                ),
+                sc.track.nude_char(),
+            ))
+        } else {
+            Self::Rich {
+                track: sc.track.clone(),
+                thumb: sc.thumb.clone(),
+            }
+        }
+    }
+}
+
+impl ScrollBarStyleDef {
+    pub fn into_scrollbar_style(self) -> ScrollBarStyle {
+        match self {
+            Self::Simple(sc) => sc.into(),
+            Self::Rich{ track, thumb } => ScrollBarStyle { track, thumb },
+        }
+    }
+}

--- a/src/serde/serde_skin.rs
+++ b/src/serde/serde_skin.rs
@@ -1,4 +1,5 @@
 use {
+    super::ScrollBarStyleDef,
     crate::{
         minimad::Alignment,
         ATTRIBUTES,
@@ -7,8 +8,15 @@ use {
         parse_compound_style,
         parse_styled_char,
         parse_line_style,
+        TableBorderChars,
     },
-    serde::{de, Deserialize},
+    serde::{
+        de,
+        Deserialize,
+        Serialize,
+        Serializer,
+        ser::SerializeMap,
+    },
     std::fmt,
 };
 
@@ -88,14 +96,8 @@ impl<'de> de::Deserialize<'de> for MadSkin {
 
                         // scrollbar
                         "scrollbar" => {
-                            // this simple deserialization covers the most frequent
-                            // cases but don't offer the whole freedom of the
-                            // ScrollbarStyle struct. I'll enable a more detailled
-                            // syntax if requested
-                            let value = map.next_value::<String>()?;
-                            let sc = parse_styled_char(&value, '▐')
-                                .map_err(de::Error::custom)?;
-                            skin.scrollbar = sc.into();
+                            let def: ScrollBarStyleDef = map.next_value()?;
+                            skin.scrollbar = def.into_scrollbar_style();
                         }
 
                         // line styles
@@ -149,6 +151,18 @@ impl<'de> de::Deserialize<'de> for MadSkin {
                             }
                         }
 
+                        // table border chars
+                        // There's currently no way to allow custom table border
+                        // chars. It would require a change in MadSkin: either
+                        // make it require a lifetime, or use a Cow for the border
+                        // chars
+                        "table_border_chars" | "table-border-chars" => {
+                            let key = map.next_value::<String>()?;
+                            if let Some(chars) = TableBorderChars::by_key(&key) {
+                                skin.table_border_chars = chars;
+                            }
+                        }
+
                         _ => {
                             let _ = map.next_value::<String>()?;
                             println!("unknown key: {key}");
@@ -163,9 +177,110 @@ impl<'de> de::Deserialize<'de> for MadSkin {
     }
 }
 
+impl Serialize for MadSkin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut skin = serializer.serialize_map(None)?;
+
+        // inline styles
+        skin.serialize_entry("bold", &self.bold)?;
+        skin.serialize_entry("italic", &self.italic)?;
+        skin.serialize_entry("strikeout", &self.strikeout)?;
+        skin.serialize_entry("inline_code", &self.inline_code)?;
+        skin.serialize_entry("ellipsis", &self.ellipsis)?;
+
+        // marker chars
+        skin.serialize_entry("bullet", &self.bullet)?;
+        skin.serialize_entry("quote", &self.quote_mark)?;
+        skin.serialize_entry("horizontal_rule", &self.horizontal_rule)?;
+
+        // scrollbar
+        let def: ScrollBarStyleDef = (&self.scrollbar).into();
+        skin.serialize_entry("scrollbar", &def)?;
+
+        // line styles
+        skin.serialize_entry("paragraph", &self.paragraph)?;
+        skin.serialize_entry("code_block", &self.code_block)?;
+        skin.serialize_entry("table", &self.table)?;
+
+        // headers
+        skin.serialize_entry("headers", &self.headers)?;
+
+        // table border chars
+        // There's currently no way to allow custom
+        if let Some(key) = self.table_border_chars.key() {
+            skin.serialize_entry("table_border_chars", key)?;
+        }
+
+        skin.end()
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum HeadersStyleInfo {
     Add(LineStyle),
     Levels(Vec<LineStyle>),
+}
+
+/// Check that serializing a skin in JSON, then deserializing this
+/// JSON into a new skin, results in an identical skin.
+#[test]
+fn skin_json_roundtrip() {
+    use {
+        crate::{
+            gray,
+            ROUNDED_TABLE_BORDER_CHARS,
+            rgb,
+            StyledChar,
+        },
+        crossterm::style::{
+            Attribute,
+            Color::*,
+        },
+        pretty_assertions::assert_eq,
+    };
+
+    let skin = MadSkin::default();
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(skin, deserialized);
+
+    let mut skin = MadSkin::no_style();
+    skin.limit_to_ascii();
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(skin, deserialized);
+
+    let skin = MadSkin::default_dark();
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(skin, deserialized);
+
+    let skin = MadSkin::default_light();
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(skin, deserialized);
+
+    let mut skin = MadSkin::default();
+    skin.set_headers_fg(AnsiValue(178));
+    skin.headers[2].set_fg(gray(22));
+    skin.bold.set_fg(Yellow);
+    skin.italic.set_fgbg(Magenta, rgb(30, 30, 40));
+    skin.bullet = StyledChar::from_fg_char(Yellow, '⟡');
+    skin.quote_mark.set_fg(Yellow);
+    skin.italic.set_fg(Magenta);
+    skin.scrollbar.thumb.set_fg(AnsiValue(178));
+    skin.table_border_chars = ROUNDED_TABLE_BORDER_CHARS;
+    skin.paragraph.align = Alignment::Center;
+    skin.table.align = Alignment::Center;
+    skin.inline_code.add_attr(Attribute::Reverse);
+    skin.paragraph.set_fgbg(Magenta, rgb(30, 30, 40));
+    skin.italic.add_attr(Attribute::Underlined);
+    skin.italic.add_attr(Attribute::OverLined);
+    let serialized = serde_json::to_string_pretty(&skin).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(skin, deserialized);
 }

--- a/src/serde/serde_styled_char.rs
+++ b/src/serde/serde_styled_char.rs
@@ -2,8 +2,9 @@ use {
     crate::{
         StyledChar,
         parse_styled_char,
+        parse::PushStyleTokens,
     },
-    serde::de,
+    serde::{de, Serialize, Serializer},
 };
 
 impl<'de> de::Deserialize<'de> for StyledChar {
@@ -16,4 +17,11 @@ impl<'de> de::Deserialize<'de> for StyledChar {
     }
 }
 
-
+impl Serialize for StyledChar {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_style_tokens_string())
+    }
+}

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -41,7 +41,7 @@ use {
 
 /// A skin defining how a parsed markdown appears on the terminal
 /// (fg and bg colors, bold, italic, underline, etc.)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MadSkin {
     pub paragraph: LineStyle,
     pub bold: CompoundStyle,

--- a/src/styled_char.rs
+++ b/src/styled_char.rs
@@ -15,7 +15,7 @@ use {
 
 /// A modifiable character which can be easily written or repeated. Can
 /// be used for bullets, horizontal rules or quote marks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StyledChar {
     compound_style: CompoundStyle,
     nude_char: char,
@@ -67,6 +67,9 @@ impl StyledChar {
     pub fn set_compound_style(&mut self, compound_style: CompoundStyle) {
         self.compound_style = compound_style;
         self.styled_char = self.compound_style.apply_to(self.nude_char);
+    }
+    pub fn compound_style(&self) -> &CompoundStyle {
+        &self.compound_style
     }
     /// Return a struct implementing `Display`, made of a (optimized) repetition
     ///  of the character with its style.

--- a/src/table_border_chars.rs
+++ b/src/table_border_chars.rs
@@ -1,6 +1,6 @@
 
 /// The set of characters to use to render table borders
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TableBorderChars {
     pub horizontal: char,
     pub vertical: char,
@@ -13,6 +13,31 @@ pub struct TableBorderChars {
     pub bottom_junction: char,
     pub left_junction: char,
     pub cross: char,
+}
+
+impl TableBorderChars {
+    /// return a key which could be used in by_key.
+    ///
+    /// (note that we're comparing the values, not the pointers)
+    pub fn key(&self) -> Option<&'static str> {
+        if self == STANDARD_TABLE_BORDER_CHARS {
+            Some("standard")
+        } else if self == ASCII_TABLE_BORDER_CHARS {
+            Some("ascii")
+        } else if self == ROUNDED_TABLE_BORDER_CHARS {
+            Some("rounded")
+        } else {
+            None
+        }
+    }
+    pub fn by_key(key: &str) -> Option<&'static Self> {
+        match key {
+            "standard" => Some(STANDARD_TABLE_BORDER_CHARS),
+            "ascii" => Some(ASCII_TABLE_BORDER_CHARS),
+            "rounded" => Some(ROUNDED_TABLE_BORDER_CHARS),
+            _ => None,
+        }
+    }
 }
 
 /// Default square tables


### PR DESCRIPTION
There was already a `serde::Deserialize` implementation for `MadSkin`.

There's now a `serde::Serialize` implementation.

Fix #19 