### PR TITLE
Update crossterm to `0.27.0` and bump minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termimad"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/termimad"
 description = "Markdown Renderer for the Terminal"
@@ -17,9 +17,9 @@ special-renders = []
 default = ["special-renders"]
 
 [dependencies]
-coolor = { version="0.8.0", features=["crossterm"] }
+coolor = { version="0.8.1", features=["crossterm"] }
 crossbeam = "0.8"
-crossterm = "=0.23.2"
+crossterm = "0.27.0"
 lazy-regex = "3"
 minimad = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -30,7 +30,7 @@ unicode-width = "0.1.10"
 [dev-dependencies]
 anyhow = "1.0"
 cli-log = "2"
-crokey = "0.4"
+crokey = "0.6.0"
 deser-hjson = "2"
 pretty_assertions = "1.4"
 serde_json = "1"
@@ -38,6 +38,7 @@ terminal-clipboard = "0.4.1"
 
 [patch.crates-io]
 # coolor = { path = "../coolor" }
+# crokey = { path = "../crokey" }
 # crossterm = { path = "../crossterm" }
 # minimad = { path = "../minimad" }
 # terminal-clipboard = { path = "../terminal-clipboard" }

--- a/examples/inputs/view.rs
+++ b/examples/inputs/view.rs
@@ -172,6 +172,9 @@ impl View {
             Event::Key(key) => self.apply_key_event(key),
             Event::Mouse(me) => self.apply_mouse_event(me, timed_event.double_click),
             Event::Resize(w, h) => self.resize(Area::new(0, 0, w, h)),
+            Event::FocusGained => false,
+            Event::FocusLost => false,
+            Event::Paste(_) => false,
         }
     }
     /// draw the view (not flushing)

--- a/examples/render-input-markdown/view.rs
+++ b/examples/render-input-markdown/view.rs
@@ -85,6 +85,9 @@ impl View {
             Event::Key(key) => self.apply_key_event(key),
             Event::Mouse(me) => self.apply_mouse_event(me, timed_event.double_click),
             Event::Resize(w, h) => self.resize(Area::new(0, 0, w, h)),
+            Event::FocusGained => false,
+            Event::FocusLost => false,
+            Event::Paste(_) => false,
         }
     }
     /// Draw the view (not flushing)

--- a/examples/stderr/main.rs
+++ b/examples/stderr/main.rs
@@ -9,6 +9,7 @@ use termimad::crossterm::{
         self,
         Event,
         KeyEvent,
+        KeyEventKind,
         KeyCode::*,
     },
     cursor,
@@ -57,7 +58,7 @@ where
     loop {
         view.write_on(w)?;
         w.flush()?;
-        if let Ok(Event::Key(KeyEvent{code, modifiers})) = event::read() {
+        if let Ok(Event::Key(KeyEvent{code, modifiers, kind: KeyEventKind::Press, ..})) = event::read() {
             if !modifiers.is_empty() {
                 continue;
             }

--- a/src/compound_style.rs
+++ b/src/compound_style.rs
@@ -58,12 +58,14 @@ impl CompoundStyle {
     pub const fn new(
         foreground_color: Option<Color>,
         background_color: Option<Color>,
+        underline_color: Option<Color>,
         attributes: Attributes,
     ) -> CompoundStyle {
         CompoundStyle {
             object_style: ContentStyle {
                 foreground_color,
                 background_color,
+                underline_color,
                 attributes,
             },
         }
@@ -92,6 +94,7 @@ impl CompoundStyle {
             object_style: ContentStyle {
                 foreground_color: Some(fg),
                 background_color: Some(bg),
+                underline_color: None,
                 attributes: Attributes::default(),
             }
         }
@@ -103,6 +106,7 @@ impl CompoundStyle {
             object_style: ContentStyle {
                 foreground_color: Some(fg),
                 background_color: None,
+                underline_color: None,
                 attributes: Attributes::default(),
             }
         }
@@ -114,6 +118,7 @@ impl CompoundStyle {
             object_style: ContentStyle {
                 foreground_color: None,
                 background_color: Some(bg),
+                underline_color: None,
                 attributes: Attributes::default(),
             }
         }

--- a/src/events/escape_sequence.rs
+++ b/src/events/escape_sequence.rs
@@ -26,7 +26,7 @@ pub struct EscapeSequence {
 impl fmt::Display for EscapeSequence {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for key in &self.keys {
-            if let KeyEvent { code: KeyCode::Char(c), modifiers: KeyModifiers::NONE } = key {
+            if let KeyEvent { code: KeyCode::Char(c), modifiers: KeyModifiers::NONE, .. } = key {
                 write!(f, "{}", c)?;
             }
         }

--- a/src/events/event_source.rs
+++ b/src/events/event_source.rs
@@ -13,6 +13,8 @@ use {
             Event,
             KeyCode,
             KeyEvent,
+            KeyEventKind,
+            KeyEventState,
             KeyModifiers,
             MouseButton,
             MouseEvent,
@@ -93,10 +95,14 @@ impl EventSource {
         let seq_start = KeyEvent {
             code: KeyCode::Char('_'),
             modifiers: KeyModifiers::ALT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
         };
         let seq_end = KeyEvent {
             code: KeyCode::Char('\\'),
             modifiers: KeyModifiers::ALT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
         };
         thread::spawn(move || {
             let mut last_up: Option<TimedClick> = None;

--- a/src/events/timed_event.rs
+++ b/src/events/timed_event.rs
@@ -13,7 +13,7 @@ use {
 };
 
 /// a user event with happening time
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimedEvent {
 
     pub time: Instant,
@@ -52,7 +52,7 @@ impl TimedEvent {
 
     /// If it's a simple mouse up and not determined to be the second click of
     /// a double click, return the coordinates
-    pub const fn as_click(self) -> Option<(u16, u16)> {
+    pub const fn as_click(&self) -> Option<(u16, u16)> {
         if self.double_click {
             return None;
         }
@@ -64,7 +64,7 @@ impl TimedEvent {
         }
     }
 
-    pub fn is_key(self, key: KeyEvent) -> bool {
+    pub fn is_key(&self, key: KeyEvent) -> bool {
         match self.event {
             Event::Key(k) if k == key => true,
             _ => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ let mut skin = MadSkin::default();
 // let's decide bold is in light gray
 skin.bold.set_fg(gray(20));
 // let's make strikeout not striked out but red, with no specific background, and bold
-skin.strikeout = CompoundStyle::new(Some(Red), None, Bold.into());
+skin.strikeout = CompoundStyle::new(Some(Red), None, None, Bold.into());
 ```
 
 **Beware:**

--- a/src/serde/serde_scrollbar_style.rs
+++ b/src/serde/serde_scrollbar_style.rs
@@ -36,6 +36,7 @@ impl From<&ScrollBarStyle> for ScrollBarStyleDef {
                 CompoundStyle::new(
                     sc.thumb.get_fg(),
                     sc.track.get_fg(),
+                    None,
                     Default::default(),
                 ),
                 sc.track.nude_char(),

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -93,7 +93,7 @@ impl Default for MadSkin {
             },
             bullet: StyledChar::from_fg_char(gray(8), '•'),
             quote_mark: StyledChar::new(
-                CompoundStyle::new(Some(gray(12)), None, Attribute::Bold.into()),
+                CompoundStyle::new(Some(gray(12)), None, None, Attribute::Bold.into()),
                 '▐',
             ),
             horizontal_rule: StyledChar::from_fg_char(gray(6), '―'),

--- a/src/views/input_field.rs
+++ b/src/views/input_field.rs
@@ -7,6 +7,8 @@ use {
             Event,
             KeyCode,
             KeyEvent,
+            KeyEventKind,
+            KeyEventState,
             KeyModifiers,
             MouseButton,
             MouseEvent,
@@ -69,10 +71,14 @@ impl InputField {
     pub const ENTER: KeyEvent = KeyEvent {
         code: KeyCode::Enter,
         modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
     };
     pub const ALT_ENTER: KeyEvent = KeyEvent {
         code: KeyCode::Enter,
         modifiers: KeyModifiers::ALT,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
     };
 
     pub fn new(area: Area) -> Self {
@@ -284,10 +290,11 @@ impl InputField {
         }
         use crate::crossterm::event::{
             KeyModifiers as Mod,
+            KeyEventKind as Kind,
         };
-        match (key.code, key.modifiers) {
-            (code, Mod::NONE) => self.apply_keycode_event(code, false),
-            (code, Mod::SHIFT) => self.apply_keycode_event(code, true),
+        match (key.code, key.modifiers, key.kind) {
+            (code, Mod::NONE, Kind::Press) => self.apply_keycode_event(code, false),
+            (code, Mod::SHIFT, Kind::Press) => self.apply_keycode_event(code, true),
             _ => false,
         }
     }
@@ -426,7 +433,7 @@ impl InputField {
             Event::Mouse(mouse_event) => {
                 self.apply_mouse_event(mouse_event, is_double_click)
             }
-            Event::Key(KeyEvent{code, modifiers}) if self.focused => {
+            Event::Key(KeyEvent{code, modifiers, ..}) if self.focused => {
                 if modifiers.is_empty() {
                     self.apply_keycode_event(code, false)
                 } else if modifiers == KeyModifiers::SHIFT {


### PR DESCRIPTION
Please see [this MR](https://github.com/Canop/crokey/pull/17) for more context. These changes are to allow `termimad` to be used with a newer version of `crossterm`.

I was aiming to simply get the tests and examples working again without breaking any existing behavior. However, it appears that there is some new functionality in the latest version of `crossterm` that this library may be able to take advantage of. if you feel that there are any additional changes I should make, please let me know and I will be happy to help.

AFAIK, these changes will need to wait on the dependent `crokey` and `coolor` MRs to go through before they can be successfully pulled.