### PR TITLE
left and right margins in line style

### DIFF
--- a/examples/indented-code/main.rs
+++ b/examples/indented-code/main.rs
@@ -1,0 +1,24 @@
+use termimad::*;
+
+static MD: &str = r#"
+# Indented Code
+
+To indent code (as demonstrated here) do this:
+
+```rust
+fn main() {
+    let mut skin = MadSkin::default();
+    skin.code_block.left_margin = 4;
+    skin.print_text(MD);
+}
+```
+
+Note that you can add some margin to other kinds of lines, not just code blocks.
+
+"#;
+
+fn main() {
+    let mut skin = MadSkin::default();
+    skin.code_block.left_margin = 4;
+    skin.print_text(MD);
+}

--- a/examples/scrollable/main.rs
+++ b/examples/scrollable/main.rs
@@ -95,10 +95,10 @@ Use any other key to quit the application.
 
 ## Area
 
-The area specifies the part of the screen where we'll display our markdown. The margin in this example is just here to show that wrapping is handled:
+The area specifies the part of the screen where we'll display our markdown.
 
     let mut area = Area::full_screen();
-    area.pad(2, 1); // let's add some margin
+    area.pad_for_max_width(120); // we don't want a too wide text column
 
 *(yes the code block centering in this example is a little too much, it's just here to show what's possible)*
 

--- a/examples/skin-file/main.rs
+++ b/examples/skin-file/main.rs
@@ -70,7 +70,7 @@ The first encountered color is the foreground color. If you want no foreground c
 
 Line styles are "paragraph", "code-block", and "table".
 
-They're defined like inline styles but accept an optional alignment (`left`, `right`, or `center`).
+They're defined like inline styles but accept an optional alignment (`left`, `right`, or `center`) and optional left and right margins.
 
 ### Styled chars
 

--- a/examples/skin-file/skin.hjson
+++ b/examples/skin-file/skin.hjson
@@ -5,8 +5,8 @@ bold: "#fb0 bold"
 italic: dim italic
 strikeout: crossedout red
 bullet: ○ yellow bold
-paragraph: gray(20)
-code_block: gray(2) gray(15) center
+paragraph: gray(20) 4 4
+code_block: gray(2) gray(15) 4
 headers: [
     yellow bold center
     yellow underlined

--- a/examples/skin-file/skin.json
+++ b/examples/skin-file/skin.json
@@ -8,8 +8,8 @@
   "quote": "▐ Yellow Bold",
   "horizontal_rule": "― ansi(238)",
   "scrollbar": "▐ ansi(178) ansi(237)",
-  "paragraph": "Magenta center",
-  "code_block": "ansi(249) ansi(235) ",
+  "paragraph": "Magenta center 4 4",
+  "code_block": "ansi(249) ansi(235) 4",
   "table": "ansi(239) center",
   "headers": [
     "ansi(178) ansi(129) Bold Underlined center",

--- a/src/composite.rs
+++ b/src/composite.rs
@@ -1,4 +1,3 @@
-
 use {
     crate::{
         Alignment,

--- a/src/fit/wrap.rs
+++ b/src/fit/wrap.rs
@@ -109,10 +109,10 @@ pub fn hard_wrap_composite<'s, 'c>(
 /// Consumes the passed array and return a new one (may contain
 /// the original lines, avoiding cloning when possible).
 /// Return an error if the width is less than 3.
-pub fn hard_wrap_lines<'s, 'k>(
+pub fn hard_wrap_lines<'s>(
     src_lines: Vec<FmtLine<'s>>,
     width: usize,
-    skin: &'k MadSkin,
+    skin: &MadSkin,
 ) -> Result<Vec<FmtLine<'s>>, InsufficientWidthError> {
     let mut src_lines = src_lines;
     let mut lines = Vec::new();

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -16,6 +16,6 @@ pub struct FmtInline<'k, 's> {
 
 impl fmt::Display for FmtInline<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.skin.write_fmt_composite(f, &self.composite, None, false)
+        self.skin.write_fmt_composite(f, &self.composite, None, false, true)
     }
 }

--- a/src/line_style.rs
+++ b/src/line_style.rs
@@ -14,9 +14,35 @@ use {
 pub struct LineStyle {
     pub compound_style: CompoundStyle,
     pub align: Alignment,
+    pub left_margin: usize,
+    pub right_margin: usize,
 }
 
 impl LineStyle {
+
+    /// Return a (left_margin, right_margin) tupple, with both values
+    /// being zeroed when they wouldn't let a width of at least 3 otherwise.
+    pub fn margins_in(&self, available_width: Option<usize>) -> (usize, usize) {
+        if let Some(width) = available_width {
+            if width < self.left_margin + self.right_margin + 3 {
+                return (0, 0);
+            }
+        }
+        (self.left_margin, self.right_margin)
+    }
+
+    pub fn new(
+        compound_style: CompoundStyle,
+        align: Alignment,
+    ) -> Self {
+        Self {
+            compound_style,
+            align,
+            left_margin: 0,
+            right_margin: 0,
+        }
+    }
+
     /// Set the foreground color to the passed color.
     #[inline(always)]
     pub fn set_fg(&mut self, color: Color) {
@@ -60,5 +86,16 @@ impl LineStyle {
 
     pub fn blend_with<C: Into<coolor::Color>>(&mut self, color: C, weight: f32) {
         self.compound_style.blend_with(color, weight);
+    }
+}
+
+impl From<CompoundStyle> for LineStyle {
+    fn from(compound_style: CompoundStyle) -> Self {
+        Self {
+            compound_style,
+            align: Alignment::Unspecified,
+            left_margin: 0,
+            right_margin: 0,
+        }
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -44,6 +44,7 @@ pub enum StyleToken {
     Color(Color),
     Attribute(Attribute),
     Align(Alignment),
+    Dimension(u16),
     /// A specified absence, meaning for example "no foreground"
     None,
 }
@@ -55,6 +56,7 @@ impl fmt::Display for StyleToken {
             Self::Color(c) => write_color(f, *c),
             Self::Attribute(a) => write_attribute(f, *a),
             Self::Align(a) => write_align(f, *a),
+            Self::Dimension(number) =>  write!(f, "{}", number),
             Self::None => write!(f, "none"),
         }
     }
@@ -108,6 +110,9 @@ pub fn style_tokens_to_string(tokens: &[StyleToken]) -> String {
 pub fn parse_style_token(s: &str) -> Result<StyleToken, ParseStyleTokenError> {
     if regex_is_match!("none"i, s) {
         return Ok(StyleToken::None);
+    }
+    if let Ok(number) = s.parse() {
+        return Ok(StyleToken::Dimension(number));
     }
     match parse_color(s) {
         Ok(color) => { return Ok(StyleToken::Color(color)); }

--- a/src/parse/parse_compound_style.rs
+++ b/src/parse/parse_compound_style.rs
@@ -52,6 +52,9 @@ impl From<&[StyleToken]> for CompoundStyle {
                 StyleToken::Align(_) => {
                     // not of use for compound styles
                 }
+                StyleToken::Dimension(_) => {
+                    // not of use for compound styles
+                }
             }
         }
         style

--- a/src/parse/parse_line_style.rs
+++ b/src/parse/parse_line_style.rs
@@ -5,7 +5,7 @@ use {
     },
 };
 
-/// Read a Minimad CompoundStyle from a string.
+/// Read a line_style from a string.
 pub fn parse_line_style(s: &str) -> Result<LineStyle, ParseStyleTokenError> {
     let tokens = parse_style_tokens(s)?;
     Ok(tokens.as_slice().into())
@@ -14,14 +14,27 @@ pub fn parse_line_style(s: &str) -> Result<LineStyle, ParseStyleTokenError> {
 impl From<&[StyleToken]> for LineStyle {
     fn from(tokens: &[StyleToken]) -> Self {
         let compound_style = tokens.into();
-        let align = tokens
-            .iter()
-            .find_map(|token| match token {
-                StyleToken::Align(a) => Some(*a),
-                _ => None,
-            })
-            .unwrap_or_default();
-        LineStyle { compound_style, align }
+        let mut left_margin = None;
+        let mut right_margin = None;
+        let mut align = Default::default();
+        for token in tokens {
+            match token {
+                StyleToken::Align(a) => {
+                    align = *a;
+                }
+                StyleToken::Dimension(number) => {
+                    if left_margin.is_some() {
+                        right_margin = Some(*number);
+                    } else {
+                        left_margin = Some(*number);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let left_margin = left_margin.unwrap_or_default() as usize;
+        let right_margin = right_margin.unwrap_or_default() as usize;
+        LineStyle { compound_style, align, left_margin, right_margin }
     }
 }
 

--- a/src/spacing.rs
+++ b/src/spacing.rs
@@ -1,5 +1,10 @@
-use crate::{compound_style::CompoundStyle, errors::Result};
-use minimad::Alignment;
+use {
+    crate::{
+        compound_style::CompoundStyle,
+        errors::Result,
+    },
+    minimad::Alignment,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Spacing {
@@ -18,7 +23,11 @@ impl Spacing {
     /// compute the number of chars to add left and write of inner_width
     /// to fill outer_width
     #[inline(always)]
-    pub const fn completions(align: Alignment, inner_width: usize, outer_width: usize) -> (usize, usize) {
+    pub const fn completions(
+        align: Alignment,
+        inner_width: usize,
+        outer_width: usize,
+    ) -> (usize, usize) {
         if inner_width >= outer_width {
             return (0, 0);
         }
@@ -76,6 +85,8 @@ impl Spacing {
         }
         Ok(())
     }
+    // FIXME use the number of chars instead of their real width,
+    // the crop writer should be used when wide characters are expected
     pub fn write_str<W>(&self, w: &mut W, s: &str, style: &CompoundStyle) -> Result<()>
     where
         W: std::io::Write,

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -78,7 +78,12 @@ struct Table {
 
 #[allow(clippy::needless_range_loop)]
 impl Table {
-    pub fn fix_columns(&mut self, lines: &mut Vec<FmtLine<'_>>, width: usize) {
+    pub fn fix_columns(
+        &mut self,
+        lines: &mut Vec<FmtLine<'_>>,
+        width: usize,
+        _skin: &MadSkin,
+    ) {
         let mut nbcols = self.nbcols;
         if nbcols == 0 || width == 0 {
             return;
@@ -244,8 +249,12 @@ fn find_tables(lines: &[FmtLine<'_>]) -> Vec<Table> {
 ///
 /// Some lines may be added to the table in the process, which means any
 ///  precedent indexing might be invalid.
-pub fn fix_all_tables(lines: &mut Vec<FmtLine<'_>>, width: usize) {
+pub fn fix_all_tables(
+    lines: &mut Vec<FmtLine<'_>>,
+    width: usize,
+    skin: &MadSkin,
+) {
     for tbl in find_tables(lines).iter_mut().rev() {
-        tbl.fix_columns(lines, width);
+        tbl.fix_columns(lines, width, skin);
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -51,11 +51,11 @@ impl<'k, 's> FmtText<'k, 's> {
             .drain(..)
             .map(|mline| FmtLine::from(mline, skin))
             .collect();
-        tbl::fix_all_tables(&mut lines, width.unwrap_or(std::usize::MAX));
+        tbl::fix_all_tables(&mut lines, width.unwrap_or(std::usize::MAX), skin);
         code::justify_blocks(&mut lines);
         if let Some(width) = width {
             if width >= 3 {
-                lines = wrap::hard_wrap_lines(lines, width)
+                lines = wrap::hard_wrap_lines(lines, width, skin)
                     .expect("width should be wide enough");
             }
         }


### PR DESCRIPTION
This lets you define left and right margins for paragraphs, code blocks, tables, etc.

Those margins don't apply in table cells, and are completely omitted when they would reduce the available width below 3.

The indented-code example shows how to use the left margin to "indent" code blocks.

Fix #11