### PR TITLE
Expose cursor position of `InputField`

### DIFF
--- a/src/views/input_field.rs
+++ b/src/views/input_field.rs
@@ -603,7 +603,6 @@ impl InputField {
                         if !is_last || displayed_width + char_width > width {
                             if self.focused && selection.contains(i, y) {
                                 self.cursor_style.queue(w, fit::ELLIPSIS)?;
-                                displayed_width += 1;
                                 // set terminal cursor position
                                 terminal_cursor_pos = Some((
                                     self.area.left + displayed_width as u16,
@@ -611,31 +610,30 @@ impl InputField {
                                 ));
                             } else {
                                 normal_style.queue(w, fit::ELLIPSIS)?;
-                                displayed_width += 1;
                             }
+                            displayed_width += 1;
                             break;
                         }
                     }
                     if self.focused && selection.contains(i, y) {
                         self.cursor_style.queue(w, c)?;
-                        displayed_width += char_width;
                         // set terminal cursor position
                         terminal_cursor_pos =
                             Some((self.area.left + displayed_width as u16, self.area.top + j));
                     } else {
-                        displayed_width += char_width;
                         normal_style.queue(w, c)?;
                     }
+                    displayed_width += char_width;
                     if displayed_width >= width {
                         break;
                     }
                 }
                 if displayed_width < width && cursor_at_end {
                     self.cursor_style.queue(w, ' ')?;
-                    displayed_width += 1;
                     // set terminal cursor position
                     terminal_cursor_pos =
                         Some((self.area.left + displayed_width as u16, self.area.top + j));
+                    displayed_width += 1;
                 }
                 while displayed_width < width {
                     normal_style.queue(w, ' ')?;

--- a/src/views/input_field.rs
+++ b/src/views/input_field.rs
@@ -4,14 +4,24 @@ use {
         crossterm::{
             cursor,
             event::{
-                Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+                Event,
+                KeyCode,
+                KeyEvent,
+                KeyModifiers,
+                MouseButton,
+                MouseEvent,
+                MouseEventKind,
             },
             queue,
-            style::{Attribute, Color, SetBackgroundColor},
+            style::{
+                Attribute,
+                Color,
+                SetBackgroundColor,
+            },
         },
         *,
     },
-    crokey::{key, KeyCombination, OneToThree},
+    crokey::{OneToThree, KeyCombination, key},
     std::io::Write,
 };
 
@@ -59,7 +69,7 @@ macro_rules! wrap_content_fun {
 
 impl InputField {
     pub const ENTER: KeyCombination = key!(enter);
-    pub const ALT_ENTER: KeyCombination = key!(alt - enter);
+    pub const ALT_ENTER: KeyCombination = key!(alt-enter);
 
     pub fn new(area: Area) -> Self {
         let focused_style = CompoundStyle::default();
@@ -272,7 +282,10 @@ impl InputField {
     /// of the input. If you want to totally handle events, you
     /// may call function like `put_char` and `del_char_left`
     /// directly.
-    pub fn apply_key_combination<K: Into<KeyCombination>>(&mut self, key: K) -> bool {
+    pub fn apply_key_combination<K: Into<KeyCombination>>(
+        &mut self,
+        key: K,
+    ) -> bool {
         if !self.focused {
             return false;
         }
@@ -418,9 +431,7 @@ impl InputField {
     pub fn apply_event(&mut self, event: &Event, is_double_click: bool) -> bool {
         match event {
             Event::Mouse(mouse_event) => self.apply_mouse_event(*mouse_event, is_double_click),
-            Event::Key(KeyEvent {
-                code, modifiers, ..
-            }) if self.focused => {
+            Event::Key(KeyEvent { code, modifiers, .. }) if self.focused => {
                 if modifiers.is_empty() {
                     self.apply_keycode_event(*code, false)
                 } else if *modifiers == KeyModifiers::SHIFT {


### PR DESCRIPTION
Exposing cursor position of `InputField` would be useful for cursor recovery cases like Canop/broot#948 .

In this PR, `InputField::display_on` and `InputField::display` are adjusted to have return type `Result<Option<(u16, u16)>, _>`. 

| Case | Return Value |
| ------- | ------------------- |
| Cursor rendered at (left, top) | `Ok(Some((left, top)))` |
| Cursor not rendered | `Ok(None)` |