### PR TITLE
breaking: directly depend on crossbeam-channel instead of pulling in all of crossbeam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["special-renders"]
 [dependencies]
 coolor = { version="1.0.0", features=["crossterm"] }
 crokey = "1.1.0"
-crossbeam = "0.8"
+crossbeam-channel = "0.5.10"
 lazy-regex = "3.2"
 minimad = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/events/event_source.rs
+++ b/src/events/event_source.rs
@@ -20,7 +20,7 @@ use {
         errors::Error,
     },
     crokey::Combiner,
-    crossbeam::channel::{
+    crossbeam_channel::{
         bounded,
         unbounded,
         Receiver,

--- a/src/events/tick_beam.rs
+++ b/src/events/tick_beam.rs
@@ -1,5 +1,5 @@
 use {
-    crossbeam::channel::{
+    crossbeam_channel::{
         Receiver,
         Sender,
     },
@@ -46,7 +46,7 @@ impl TickBeamHandle {
 
 impl<P> Ticker<P> {
     pub fn new() -> Self {
-        let (tick_sender, tick_receiver) = crossbeam::channel::unbounded();
+        let (tick_sender, tick_receiver) = crossbeam_channel::unbounded();
         Self {
             next_id: 0,
             beams: Vec::new(),
@@ -76,7 +76,7 @@ impl<P: Copy + Send + 'static> Ticker<P> {
     pub fn start_beam(&mut self, mission: TickBeam<P>) -> TickBeamId {
         let id = self.next_id;
         self.next_id += 1;
-        let (interrupt_sender, interrupt_receiver) = crossbeam::channel::bounded(1);
+        let (interrupt_sender, interrupt_receiver) = crossbeam_channel::bounded(1);
         let tick_sender = self.tick_sender.clone();
         thread::spawn(move || {
             let mut remaining_count = mission.remaining_count;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use {
     compound_style::*,
     coolor,
     crokey::crossterm,
-    crossbeam,
+    crossbeam_channel,
     displayable_line::DisplayableLine,
     errors::Error,
     events::{


### PR DESCRIPTION
> [!WARNING]
> this is a breaking change, since you have previously been re-exporting crossbeam.

termimad does not actually need most of the features of `crossbeam`, it only needs its channel. so you can save on a few unneeded dependencies if you just depend on the `crossbeam-channel` directly.

at this point it might be worth it to consider just using the std mpsc channel (or putting crossbeam behind a feature flag), as since [rust 1.67](https://github.com/rust-lang/rust/pull/93563) the std mpsc and the crossbeam channel are mostly the same performance wise and the extra functionality that crossbeam provides is, as far as i can tell, not used here.