### PR TITLE
update thiserror to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crossbeam = "0.8"
 lazy-regex = "3.2"
 minimad = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+thiserror = "2.0"
 unicode-width = "0.1.11"
 # cli-log = "2.0"
 

--- a/src/fit/fit_error.rs
+++ b/src/fit/fit_error.rs
@@ -1,13 +1,6 @@
-use std::fmt;
-
 /// Error thrown when fitting isn't possible
 #[derive(thiserror::Error, Debug)]
+#[error("Insufficient available width ({available_width})")]
 pub struct InsufficientWidthError {
     pub available_width: usize,
-}
-
-impl fmt::Display for InsufficientWidthError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Insufficient available width ({})", self.available_width)
-    }
 }

--- a/src/parse/parse_color.rs
+++ b/src/parse/parse_color.rs
@@ -11,7 +11,7 @@ use {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ParseColorError {
-    #[error("'not a recognized color")]
+    #[error("not a recognized color")]
     Unrecognized,
     #[error("grey level must be between 0 and 23 (got {level})")]
     InvalidGreyLevel { level: u8 },


### PR DESCRIPTION
update thiserror to version 2, released november last year. full log of breaking changes [here](https://github.com/dtolnay/thiserror/releases/2.0.0). shouldn't impact msrv.

unlike https://github.com/Canop/crokey/pull/25 no direct reason, other than a general feeling of the rust ecosystem as a whole moving towards the new release and not wanting to have multiple versions of thiserror in my dependency graph for no reason.

if you don't want to update to version 2, i can just drop the thiserror dependency and write the impls manually, if you prefer.